### PR TITLE
chore: bump Go 1.18→1.26, fix typos, clean up tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/taigrr/most-specific-period
 
-go 1.18
+go 1.26

--- a/main.go
+++ b/main.go
@@ -41,7 +41,7 @@ func warnMessage() {
 }
 
 func helpMessage() {
-	fmt.Print("\nmost-significant-period [-h][-d]\n\nGenerates a timeline of periods and will provide a most significant period if available.\n\n-h\tShows this help menut\n-d\tProvide a RFC 3339 time to provide an alternate point for calculating MSP.")
+	fmt.Print("\nmost-specific-period [-h][-d]\n\nGenerates a timeline of periods and will provide a most specific period if available.\n\n-h\tShows this help menu\n-d\tProvide an RFC 3339 time to provide an alternate point for calculating MSP.")
 }
 
 func main() {

--- a/msp/changeover_test.go
+++ b/msp/changeover_test.go
@@ -1,7 +1,6 @@
 package msp
 
 import (
-	"fmt"
 	"testing"
 	"time"
 )
@@ -148,7 +147,7 @@ func TestGetChangeOvers(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		t.Run(fmt.Sprintf("%s", tc.testID), func(t *testing.T) {
+		t.Run(tc.testID, func(t *testing.T) {
 			changeovers := GetChangeOvers(tc.periods...)
 			if !slicesEqual(changeovers, tc.result) {
 				t.Errorf("Expected %v but got %v", tc.result, changeovers)
@@ -320,7 +319,7 @@ func TestFlattenPeriods(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		t.Run(fmt.Sprintf("%s", tc.testID), func(t *testing.T) {
+		t.Run(tc.testID, func(t *testing.T) {
 			changeovers := FlattenPeriods(tc.periods...)
 			if !slicesEqual(changeovers, tc.result) {
 				t.Errorf("Expected %v but got %v", tc.result, changeovers)
@@ -468,7 +467,7 @@ func TestGetNextChangeOver(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		t.Run(fmt.Sprintf("%s", tc.testID), func(t *testing.T) {
+		t.Run(tc.testID, func(t *testing.T) {
 			ts, err := GetNextChangeOver(now, tc.periods...)
 			if tc.err != err {
 				t.Errorf("Error %v does not match expected %v", tc.err, err)

--- a/msp/errors.go
+++ b/msp/errors.go
@@ -5,9 +5,9 @@ import (
 )
 
 var (
-	// ErrEndAfterStart occurs when a period given has an end time after its start time
+	// ErrEndAfterStart occurs when a period's start time is after its end time
 	ErrEndAfterStart = errors.New("error: start time is after end time")
-	// ErrNoValidPeriods occurs when an empty set of periods is passed or when ll periods are invalid
+	// ErrNoValidPeriods occurs when an empty set of periods is passed or when all periods are invalid
 	ErrNoValidPeriods = errors.New("error: no valid periods available")
 	// ErrNoNextChangeover occurs when GetNextChangeover is called but there are no changeovers after t
 	ErrNoNextChangeover = errors.New("error: no valid changeovers available")

--- a/msp/msp_test.go
+++ b/msp/msp_test.go
@@ -1,7 +1,6 @@
 package msp
 
 import (
-	"fmt"
 	"testing"
 	"time"
 )
@@ -146,7 +145,7 @@ func TestMostSpecificPeriod(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		t.Run(fmt.Sprintf("%s", tc.testID), func(t *testing.T) {
+		t.Run(tc.testID, func(t *testing.T) {
 			id, err := MostSpecificPeriod(tc.ts, tc.periods...)
 			if id != tc.result {
 				t.Errorf("ID '%s' does not match expected '%s'", id, tc.result)

--- a/msp/timeline_test.go
+++ b/msp/timeline_test.go
@@ -263,7 +263,7 @@ func TestGenerateTime(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		t.Run(fmt.Sprintf("%s", tc.testID), func(t *testing.T) {
+		t.Run(tc.testID, func(t *testing.T) {
 			timeline := GenerateTimeline(tc.periods...)
 			if len(timeline) != len(tc.result) {
 				t.Fatalf("Time line had %d results, expected %d", len(timeline), len(tc.result))

--- a/msp/types.go
+++ b/msp/types.go
@@ -2,6 +2,9 @@ package msp
 
 import "time"
 
+// Compile-time interface check.
+var _ Period = TimeWindow{}
+
 type Period interface {
 	GetStartTime() time.Time
 	GetEndTime() time.Time


### PR DESCRIPTION
## Changes
- Updated Go directive from 1.18 to 1.26
- Fixed help text typos: 'menut' → 'menu', 'most-significant' → 'most-specific'
- Fixed error comment typo: 'when ll periods' → 'when all periods'
- Removed unnecessary `fmt.Sprintf` wrapping in test run names
- Removed unused `fmt` imports from test files
- Added compile-time interface check for `TimeWindow`

## Testing
- All tests pass with `-race` flag
- `go vet` clean
- Builds successfully