### PR TITLE
fix(msp): resolve staticcheck warning and fix typo

### DIFF
--- a/msp/msp.go
+++ b/msp/msp.go
@@ -12,7 +12,7 @@ func MostSpecificPeriod(ts time.Time, periods ...Period) (id string, err error) 
 		return "", ErrNoValidPeriods
 	}
 	// find the shortest duration
-	d, err := GetDuration(periods[0].GetStartTime(), periods[0].GetEndTime())
+	d, _ := GetDuration(periods[0].GetStartTime(), periods[0].GetEndTime())
 	for _, x := range periods {
 		p, err := GetDuration(x.GetStartTime(), x.GetEndTime())
 		if err == nil && p < d {
@@ -34,7 +34,7 @@ func MostSpecificPeriod(ts time.Time, periods ...Period) (id string, err error) 
 			newest = x.GetStartTime()
 		}
 	}
-	// Determine whichever of these periods have the same start time in addtion to duration
+	// Determine whichever of these periods have the same start time in addition to duration
 	var matchingDurationsAndStartTimes []Period
 	for _, x := range matchingDurations {
 		if x.GetStartTime() == newest {


### PR DESCRIPTION
## Changes

- Fix SA4006 staticcheck warning: the `err` value from the initial `GetDuration` call on line 15 was never used (shadowed by loop variable). Changed to blank identifier.
- Fix typo in comment: 'addtion' → 'addition'

## Testing

- `go test -race ./...` passes
- `staticcheck ./...` clean