### PR TITLE
fix(msp): compare equal start times by instant

### DIFF
--- a/msp/msp.go
+++ b/msp/msp.go
@@ -41,7 +41,7 @@ func MostSpecificPeriod(ts time.Time, periods ...Period) (id string, err error) 
 	// Determine whichever of these periods have the same start time in addition to duration
 	var matchingDurationsAndStartTimes []Period
 	for _, x := range matchingDurations {
-		if x.GetStartTime() == newest {
+		if x.GetStartTime().Equal(newest) {
 			matchingDurationsAndStartTimes = append(matchingDurationsAndStartTimes, x)
 		}
 	}

--- a/msp/msp_test.go
+++ b/msp/msp_test.go
@@ -306,3 +306,22 @@ func TestMostSpecificPeriod(t *testing.T) {
 		})
 	}
 }
+
+func TestMostSpecificPeriodEqualStartTimesAcrossLocations(t *testing.T) {
+	utc := time.Date(2026, time.January, 15, 12, 0, 0, 0, time.UTC)
+	est := time.FixedZone("EST", -5*60*60)
+	startInEST := utc.In(est)
+	ts := utc.Add(30 * time.Minute)
+	end := ts.Add(30 * time.Minute)
+
+	id, err := MostSpecificPeriod(ts,
+		TimeWindow{StartTime: utc, EndTime: end, Identifier: "A"},
+		TimeWindow{StartTime: startInEST, EndTime: end, Identifier: "B"},
+	)
+	if err != nil {
+		t.Fatalf("MostSpecificPeriod returned unexpected error: %v", err)
+	}
+	if id != "B" {
+		t.Fatalf("expected lexicographically last identifier for equal start times, got %q", id)
+	}
+}


### PR DESCRIPTION
## Summary
- compare equal start times with time.Time.Equal instead of ==
- add a regression test covering identical instants represented in different locations

## Testing
- go test ./...