### PR TITLE
fix: avoid GenerateTimeline panic for invalid periods

### DIFF
--- a/msp/timeline.go
+++ b/msp/timeline.go
@@ -43,6 +43,9 @@ func GenerateTimeline(periods ...Period) (out []Period) {
 	}
 	periodsByID := make(map[string]Period)
 	ids := FlattenPeriods(periods...)
+	if len(ids) == 0 {
+		return out
+	}
 	for _, val := range periods {
 		id := val.GetIdentifier()
 		periodsByID[id] = val

--- a/msp/timeline_test.go
+++ b/msp/timeline_test.go
@@ -260,6 +260,18 @@ func TestGenerateTime(t *testing.T) {
 				},
 			},
 		},
+		{
+			testID: "only invalid periods returns empty timeline",
+			ts:     now,
+			result: []string{},
+			periods: []Period{
+				TimeWindow{
+					StartTime:  now.Add(time.Minute),
+					EndTime:    now.Add(-time.Minute),
+					Identifier: "A",
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
## Summary
- return an empty timeline when no valid changeovers can be produced
- add regression coverage for periods with invalid start/end ordering

## Testing
- go test ./...
- go test -race ./...
- golangci-lint run